### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,10 @@ module.exports = {
   mode: 'development',
   devServer: {
     historyApiFallback: true,
-    contentBase: path.resolve(__dirname, './dist'),
+    //contentBase: path.resolve(__dirname, './dist'), //Descontinuado en la nueva versión de webpack
+    static: {
+      directory: path.resolve(__dirname, '/dist'),
+    },
     open: true,
     compress: true,
     hot: true,


### PR DESCRIPTION
En las últimas versiones de webpack la opción contentBase es desconocida:

> tutorial-webpack5@1.0.0 start
> webpack serve

[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an **unknown property 'contentBase'**. These properties are valid: object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?, hot?, http2?, https?, ipc?, liveReload?, magicHtml?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, port?, proxy?, server?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?, webSocketServer? }